### PR TITLE
refactor key size 

### DIFF
--- a/node/rpc/src/kv_rpc_server/api.rs
+++ b/node/rpc/src/kv_rpc_server/api.rs
@@ -2,7 +2,7 @@ use ethereum_types::{H160, H256};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 
-use crate::types::ValueSegment;
+use crate::types::{ValueSegment, Segment};
 
 #[rpc(server, client, namespace = "kv")]
 pub trait KeyValueRpc {
@@ -13,7 +13,7 @@ pub trait KeyValueRpc {
     async fn get_value(
         &self,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         start_index: u64,
         len: u64,
         version: Option<u64>,
@@ -30,7 +30,7 @@ pub trait KeyValueRpc {
         &self,
         account: H160,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 
@@ -46,7 +46,7 @@ pub trait KeyValueRpc {
     async fn is_special_key(
         &self,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 
@@ -55,7 +55,7 @@ pub trait KeyValueRpc {
         &self,
         account: H160,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 

--- a/node/rpc/src/kv_rpc_server/api.rs
+++ b/node/rpc/src/kv_rpc_server/api.rs
@@ -13,7 +13,7 @@ pub trait KeyValueRpc {
     async fn get_value(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         start_index: u64,
         len: u64,
         version: Option<u64>,
@@ -30,7 +30,7 @@ pub trait KeyValueRpc {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 
@@ -46,7 +46,7 @@ pub trait KeyValueRpc {
     async fn is_special_key(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 
@@ -55,7 +55,7 @@ pub trait KeyValueRpc {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool>;
 

--- a/node/rpc/src/kv_rpc_server/api.rs
+++ b/node/rpc/src/kv_rpc_server/api.rs
@@ -2,7 +2,7 @@ use ethereum_types::{H160, H256};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 
-use crate::types::{ValueSegment, Segment};
+use crate::types::{Segment, ValueSegment};
 
 #[rpc(server, client, namespace = "kv")]
 pub trait KeyValueRpc {

--- a/node/rpc/src/kv_rpc_server/impl.rs
+++ b/node/rpc/src/kv_rpc_server/impl.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::error;
 use crate::types::ValueSegment;
 use crate::Context;
@@ -23,7 +25,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
     async fn get_value(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         start_index: u64,
         len: u64,
         version: Option<u64>,
@@ -38,7 +40,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
 
         let store_read = self.ctx.store.read().await;
         if let Some((stream_write, latest_version)) = store_read
-            .get_stream_key_value(stream_id, key, before_version)
+            .get_stream_key_value(stream_id, Arc::new(key), before_version)
             .await?
         {
             if start_index > stream_write.end_index - stream_write.start_index {
@@ -90,7 +92,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_hasWritePermission()");
@@ -102,7 +104,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .has_write_permission(account, stream_id, key, before_version)
+            .has_write_permission(account, stream_id, Arc::new(key), before_version)
             .await?)
     }
 
@@ -128,7 +130,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
     async fn is_special_key(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_isSpecialKey()");
@@ -140,7 +142,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .is_special_key(stream_id, key, before_version)
+            .is_special_key(stream_id, Arc::new(key), before_version)
             .await?)
     }
 
@@ -148,7 +150,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Vec<u8>,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_isWriterOfKey()");
@@ -160,7 +162,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .is_writer_of_key(account, stream_id, key, before_version)
+            .is_writer_of_key(account, stream_id, Arc::new(key), before_version)
             .await?)
     }
 

--- a/node/rpc/src/kv_rpc_server/impl.rs
+++ b/node/rpc/src/kv_rpc_server/impl.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::error;
+use crate::types::Segment;
 use crate::types::ValueSegment;
 use crate::Context;
 use ethereum_types::H160;
@@ -25,7 +26,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
     async fn get_value(
         &self,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         start_index: u64,
         len: u64,
         version: Option<u64>,
@@ -40,7 +41,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
 
         let store_read = self.ctx.store.read().await;
         if let Some((stream_write, latest_version)) = store_read
-            .get_stream_key_value(stream_id, Arc::new(key), before_version)
+            .get_stream_key_value(stream_id, Arc::new(key.0), before_version)
             .await?
         {
             if start_index > stream_write.end_index - stream_write.start_index {
@@ -92,7 +93,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
         &self,
         account: H160,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_hasWritePermission()");
@@ -104,7 +105,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .has_write_permission(account, stream_id, Arc::new(key), before_version)
+            .has_write_permission(account, stream_id, Arc::new(key.0), before_version)
             .await?)
     }
 
@@ -130,7 +131,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
     async fn is_special_key(
         &self,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_isSpecialKey()");
@@ -142,7 +143,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .is_special_key(stream_id, Arc::new(key), before_version)
+            .is_special_key(stream_id, Arc::new(key.0), before_version)
             .await?)
     }
 
@@ -150,7 +151,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
         &self,
         account: H160,
         stream_id: H256,
-        key: Vec<u8>,
+        key: Segment,
         version: Option<u64>,
     ) -> RpcResult<bool> {
         debug!("kv_isWriterOfKey()");
@@ -162,7 +163,7 @@ impl KeyValueRpcServer for KeyValueRpcServerImpl {
             .store
             .read()
             .await
-            .is_writer_of_key(account, stream_id, Arc::new(key), before_version)
+            .is_writer_of_key(account, stream_id, Arc::new(key.0), before_version)
             .await?)
     }
 

--- a/node/shared_types/src/lib.rs
+++ b/node/shared_types/src/lib.rs
@@ -12,6 +12,7 @@ use ssz::Encode;
 use ssz_derive::{Decode as DeriveDecode, Encode as DeriveEncode};
 use std::collections::HashSet;
 use std::hash::Hasher;
+use std::sync::Arc;
 use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 use tracing::debug;
 
@@ -274,7 +275,7 @@ impl FileProof {
 #[derive(Debug)]
 pub struct StreamRead {
     pub stream_id: H256,
-    pub key: H256,
+    pub key: Arc<Vec<u8>>,
 }
 
 #[derive(Debug)]
@@ -285,7 +286,7 @@ pub struct StreamReadSet {
 #[derive(Debug)]
 pub struct StreamWrite {
     pub stream_id: H256,
-    pub key: H256,
+    pub key: Arc<Vec<u8>>,
     // start index in bytes
     pub start_index: u64,
     // end index in bytes
@@ -307,7 +308,7 @@ pub struct AccessControlSet {
 pub struct AccessControl {
     pub op_type: u8,
     pub stream_id: H256,
-    pub key: H256,
+    pub key: Arc<Vec<u8>>,
     pub account: H160,
     pub operator: H160,
 }

--- a/node/storage_with_stream/src/store/mod.rs
+++ b/node/storage_with_stream/src/store/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use ethereum_types::{H160, H256};
 use shared_types::{AccessControlSet, StreamWriteSet, Transaction};
@@ -41,7 +43,7 @@ pub trait StreamRead {
     async fn get_latest_version_before(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         before: u64,
     ) -> Result<u64>;
 
@@ -49,7 +51,7 @@ pub trait StreamRead {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<bool>;
 
@@ -57,13 +59,18 @@ pub trait StreamRead {
 
     async fn is_admin(&self, account: H160, stream_id: H256, version: u64) -> Result<bool>;
 
-    async fn is_special_key(&self, stream_id: H256, key: H256, version: u64) -> Result<bool>;
+    async fn is_special_key(
+        &self,
+        stream_id: H256,
+        key: Arc<Vec<u8>>,
+        version: u64,
+    ) -> Result<bool>;
 
     async fn is_writer_of_key(
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<bool>;
 
@@ -77,7 +84,7 @@ pub trait StreamRead {
     async fn get_stream_key_value(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<Option<(shared_types::StreamWrite, u64)>>;
 }

--- a/node/storage_with_stream/src/store/store_manager.rs
+++ b/node/storage_with_stream/src/store/store_manager.rs
@@ -6,6 +6,7 @@ use shared_types::{
     FlowRangeProof, StreamWriteSet, Transaction,
 };
 use std::path::Path;
+use std::sync::Arc;
 use storage::log_store::config::Configurable;
 use storage::log_store::log_manager::LogConfig;
 use storage::log_store::{LogStoreChunkRead, LogStoreChunkWrite, LogStoreRead, LogStoreWrite};
@@ -224,7 +225,7 @@ impl StreamRead for StoreManager {
     async fn get_latest_version_before(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         before: u64,
     ) -> Result<u64> {
         self.stream_store
@@ -236,7 +237,7 @@ impl StreamRead for StoreManager {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<bool> {
         self.stream_store
@@ -254,7 +255,12 @@ impl StreamRead for StoreManager {
             .await
     }
 
-    async fn is_special_key(&self, stream_id: H256, key: H256, version: u64) -> Result<bool> {
+    async fn is_special_key(
+        &self,
+        stream_id: H256,
+        key: Arc<Vec<u8>>,
+        version: u64,
+    ) -> Result<bool> {
         self.stream_store
             .is_special_key(stream_id, key, version)
             .await
@@ -264,7 +270,7 @@ impl StreamRead for StoreManager {
         &self,
         account: H160,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<bool> {
         self.stream_store
@@ -286,7 +292,7 @@ impl StreamRead for StoreManager {
     async fn get_stream_key_value(
         &self,
         stream_id: H256,
-        key: H256,
+        key: Arc<Vec<u8>>,
         version: u64,
     ) -> Result<Option<(shared_types::StreamWrite, u64)>> {
         self.stream_store

--- a/node/stream/src/stream_manager/stream_replayer.rs
+++ b/node/stream/src/stream_manager/stream_replayer.rs
@@ -184,7 +184,7 @@ impl StreamReplayer {
         if key_size == 0 {
             bail!(ParseError::InvalidData);
         }
-        Ok(stream_reader.next(key_size).await?)
+        stream_reader.next(key_size).await
     }
 
     async fn parse_stream_read_set(

--- a/node/stream/src/stream_manager/stream_replayer.rs
+++ b/node/stream/src/stream_manager/stream_replayer.rs
@@ -177,13 +177,9 @@ impl StreamReplayer {
     }
 
     async fn parse_key(&self, stream_reader: &mut StreamReader<'_>) -> Result<Vec<u8>> {
-        let key_size = u64::from_be_bytes(
-            stream_reader
-                .next(STREAM_KEY_LEN_SIZE)
-                .await?
-                .try_into()
-                .unwrap(),
-        );
+        let mut key_size_in_bytes = vec![0x0; (8 - STREAM_KEY_LEN_SIZE) as usize];
+        key_size_in_bytes.append(&mut stream_reader.next(STREAM_KEY_LEN_SIZE).await?);
+        let key_size = u64::from_be_bytes(key_size_in_bytes.try_into().unwrap());
         // key should not be empty
         if key_size == 0 {
             bail!(ParseError::InvalidData);

--- a/node/stream/src/stream_manager/stream_replayer.rs
+++ b/node/stream/src/stream_manager/stream_replayer.rs
@@ -179,6 +179,10 @@ impl StreamReplayer {
     async fn parse_key(&self, stream_reader: &mut StreamReader<'_>) -> Result<Vec<u8>> {
         let key_size =
             u64::from_be_bytes(stream_reader.next(VERSION_SIZE).await?.try_into().unwrap());
+        // key should not be empty
+        if key_size == 0 {
+            bail!(ParseError::InvalidData);
+        }
         Ok(stream_reader.next(key_size).await?)
     }
 

--- a/node/stream/src/stream_manager/stream_replayer.rs
+++ b/node/stream/src/stream_manager/stream_replayer.rs
@@ -9,6 +9,7 @@ use shared_types::{
 use ssz::Decode;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::str;
 use std::{cmp, sync::Arc, time::Duration};
 use storage_with_stream::error::Error;
 use storage_with_stream::log_store::log_manager::ENTRY_SIZE;
@@ -21,7 +22,7 @@ use super::RETRY_WAIT_MS;
 
 const MAX_LOAD_ENTRY_SIZE: u64 = 10;
 const STREAM_ID_SIZE: u64 = 32;
-const STREAM_KEY_SIZE: u64 = 32;
+const STREAM_KEY_LEN_SIZE: u64 = 3;
 const SET_LEN_SIZE: u64 = 4;
 const DATA_LEN_SIZE: u64 = 8;
 const VERSION_SIZE: u64 = 8;
@@ -34,9 +35,17 @@ enum ReplayResult {
     DataParseError(String),
     VersionConfliction,
     TagsMismatch,
-    WritePermissionDenied(H256, H256),
-    AccessControlPermissionDenied(u8, H256, H256, H160),
+    WritePermissionDenied(H256, Arc<Vec<u8>>),
+    AccessControlPermissionDenied(u8, H256, Arc<Vec<u8>>, H160),
     DataUnavailable,
+}
+
+fn truncated_key(key: &[u8]) -> String {
+    let key_str = str::from_utf8(key).unwrap_or("UNKNOWN");
+    match key_str.char_indices().nth(32) {
+        None => key_str.to_owned(),
+        Some((idx, _)) => key_str[0..idx].to_owned(),
+    }
 }
 
 impl fmt::Display for ReplayResult {
@@ -48,16 +57,17 @@ impl fmt::Display for ReplayResult {
             ReplayResult::TagsMismatch => write!(f, "TagsMismatch"),
             ReplayResult::WritePermissionDenied(stream_id, key) => write!(
                 f,
-                "WritePermissionDenied: stream: {:?}, key: {:?}",
-                stream_id, key
+                "WritePermissionDenied: stream: {:?}, key: {}",
+                stream_id,
+                truncated_key(key),
             ),
             ReplayResult::AccessControlPermissionDenied(op_type, stream_id, key, account) => {
                 write!(
                     f,
-                    "AccessControlPermissionDenied: operation: {}, stream: {:?}, key: {:?}, account: {:?}",
+                    "AccessControlPermissionDenied: operation: {}, stream: {:?}, key: {}, account: {:?}",
                     to_access_control_op_name(*op_type),
                     stream_id,
-                    key,
+                    truncated_key(key),
                     account
                 )
             }
@@ -166,11 +176,23 @@ impl StreamReplayer {
         ))
     }
 
+    async fn parse_key(&self, stream_reader: &mut StreamReader<'_>) -> Result<Vec<u8>> {
+        let key_size =
+            u64::from_be_bytes(stream_reader.next(VERSION_SIZE).await?.try_into().unwrap());
+        Ok(stream_reader.next(key_size).await?)
+    }
+
     async fn parse_stream_read_set(
         &self,
         stream_reader: &mut StreamReader<'_>,
     ) -> Result<StreamReadSet> {
-        let size = u32::from_be_bytes(stream_reader.next(SET_LEN_SIZE).await?.try_into().unwrap());
+        let size = u32::from_be_bytes(
+            stream_reader
+                .next(STREAM_KEY_LEN_SIZE)
+                .await?
+                .try_into()
+                .unwrap(),
+        );
         if size > MAX_SIZE_LEN {
             bail!(ParseError::ListTooLong);
         }
@@ -181,8 +203,7 @@ impl StreamReplayer {
             stream_read_set.stream_reads.push(StreamRead {
                 stream_id: H256::from_ssz_bytes(&stream_reader.next(STREAM_ID_SIZE).await?)
                     .map_err(Error::from)?,
-                key: H256::from_ssz_bytes(&stream_reader.next(STREAM_KEY_SIZE).await?)
-                    .map_err(Error::from)?,
+                key: Arc::new(self.parse_key(stream_reader).await?),
             });
         }
         Ok(stream_read_set)
@@ -203,7 +224,7 @@ impl StreamReplayer {
                 .store
                 .read()
                 .await
-                .get_latest_version_before(stream_read.stream_id, stream_read.key, tx.seq)
+                .get_latest_version_before(stream_read.stream_id, stream_read.key.clone(), tx.seq)
                 .await?
                 > version
             {
@@ -229,16 +250,15 @@ impl StreamReplayer {
         for _ in 0..(size as usize) {
             let stream_id = H256::from_ssz_bytes(&stream_reader.next(STREAM_ID_SIZE).await?)
                 .map_err(Error::from)?;
-            let key = H256::from_ssz_bytes(&stream_reader.next(STREAM_KEY_SIZE).await?)
-                .map_err(Error::from)?;
+            let key = Arc::new(self.parse_key(stream_reader).await?);
             let start_index = write_data_start_index;
             let end_index = write_data_start_index
                 + u64::from_be_bytes(stream_reader.next(DATA_LEN_SIZE).await?.try_into().unwrap());
             stream_writes.insert(
-                (stream_id, key),
+                (stream_id, key.clone()),
                 StreamWrite {
                     stream_id,
-                    key,
+                    key: key.clone(),
                     start_index,
                     end_index,
                 },
@@ -269,7 +289,7 @@ impl StreamReplayer {
             }
             // check version confiction
             if store_read
-                .get_latest_version_before(stream_write.stream_id, stream_write.key, tx.seq)
+                .get_latest_version_before(stream_write.stream_id, stream_write.key.clone(), tx.seq)
                 .await?
                 > version
             {
@@ -277,12 +297,17 @@ impl StreamReplayer {
             }
             // check write permission
             if !(store_read
-                .has_write_permission(tx.sender, stream_write.stream_id, stream_write.key, tx.seq)
+                .has_write_permission(
+                    tx.sender,
+                    stream_write.stream_id,
+                    stream_write.key.clone(),
+                    tx.seq,
+                )
                 .await?)
             {
                 return Ok(Some(ReplayResult::WritePermissionDenied(
                     stream_write.stream_id,
-                    stream_write.key,
+                    stream_write.key.clone(),
                 )));
             }
         }
@@ -310,7 +335,7 @@ impl StreamReplayer {
                 let op_meta = (
                     AccessControlOps::GRANT_ADMIN_ROLE & 0xf0,
                     *id,
-                    H256::zero(),
+                    Arc::new(vec![]),
                     tx.sender,
                 );
                 access_ops.insert(
@@ -318,7 +343,7 @@ impl StreamReplayer {
                     AccessControl {
                         op_type: AccessControlOps::GRANT_ADMIN_ROLE,
                         stream_id: *id,
-                        key: H256::zero(),
+                        key: Arc::new(vec![]),
                         account: tx.sender,
                         operator: H160::zero(),
                     },
@@ -342,7 +367,7 @@ impl StreamReplayer {
             let stream_id = H256::from_ssz_bytes(&stream_reader.next(STREAM_ID_SIZE).await?)
                 .map_err(Error::from)?;
             let mut account = H160::zero();
-            let mut key = H256::zero();
+            let mut key = Arc::new(vec![]);
             match op_type {
                 // stream_id + account
                 AccessControlOps::GRANT_ADMIN_ROLE
@@ -353,14 +378,12 @@ impl StreamReplayer {
                 }
                 // stream_id + key
                 AccessControlOps::SET_KEY_TO_NORMAL | AccessControlOps::SET_KEY_TO_SPECIAL => {
-                    key = H256::from_ssz_bytes(&stream_reader.next(STREAM_KEY_SIZE).await?)
-                        .map_err(Error::from)?;
+                    key = Arc::new(self.parse_key(stream_reader).await?);
                 }
                 // stream_id + key + account
                 AccessControlOps::GRANT_SPECIAL_WRITER_ROLE
                 | AccessControlOps::REVOKE_SPECIAL_WRITER_ROLE => {
-                    key = H256::from_ssz_bytes(&stream_reader.next(STREAM_KEY_SIZE).await?)
-                        .map_err(Error::from)?;
+                    key = Arc::new(self.parse_key(stream_reader).await?);
                     account = H160::from_ssz_bytes(&stream_reader.next(ADDRESS_SIZE).await?)
                         .map_err(Error::from)?;
                 }
@@ -369,8 +392,7 @@ impl StreamReplayer {
                     account = tx.sender;
                 }
                 AccessControlOps::RENOUNCE_SPECIAL_WRITER_ROLE => {
-                    key = H256::from_ssz_bytes(&stream_reader.next(STREAM_KEY_SIZE).await?)
-                        .map_err(Error::from)?;
+                    key = Arc::new(self.parse_key(stream_reader).await?);
                     account = tx.sender;
                 }
                 // unexpected type
@@ -378,7 +400,7 @@ impl StreamReplayer {
                     bail!(ParseError::InvalidData);
                 }
             }
-            let op_meta = (op_type & 0xf0, stream_id, key, account);
+            let op_meta = (op_type & 0xf0, stream_id, key.clone(), account);
             if op_type != AccessControlOps::GRANT_ADMIN_ROLE
                 || (!access_ops.contains_key(&op_meta) && account != tx.sender)
             {
@@ -387,7 +409,7 @@ impl StreamReplayer {
                     AccessControl {
                         op_type,
                         stream_id,
-                        key,
+                        key: key.clone(),
                         account,
                         operator: tx.sender,
                     },
@@ -427,7 +449,7 @@ impl StreamReplayer {
                         return Ok(Some(ReplayResult::AccessControlPermissionDenied(
                             access_control.op_type,
                             access_control.stream_id,
-                            access_control.key,
+                            access_control.key.clone(),
                             access_control.account,
                         )));
                     }

--- a/node/stream/src/stream_manager/stream_replayer.rs
+++ b/node/stream/src/stream_manager/stream_replayer.rs
@@ -41,6 +41,9 @@ enum ReplayResult {
 }
 
 fn truncated_key(key: &[u8]) -> String {
+    if key.is_empty() {
+        return "NONE".to_owned();
+    }
     let key_str = str::from_utf8(key).unwrap_or("UNKNOWN");
     match key_str.char_indices().nth(32) {
         None => key_str.to_owned(),

--- a/tests/kv_access_control_test.py
+++ b/tests/kv_access_control_test.py
@@ -6,7 +6,7 @@ from os import access
 import random
 from test_framework.test_framework import TestFramework
 from utility.kv import (MAX_U64, op_with_address, op_with_key, STREAM_DOMAIN, with_prefix, is_access_control_permission_denied, is_write_permission_denied,
-                        MAX_STREAM_ID, pad, to_key, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
+                        MAX_STREAM_ID, pad, to_key_with_size, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
 from utility.submission import submit_data
 from utility.submission import create_submission
 from utility.utils import (

--- a/tests/kv_data_fetcher_test.py
+++ b/tests/kv_data_fetcher_test.py
@@ -111,7 +111,7 @@ class DataFetcherTest(TestFramework):
         wait_until(
             lambda: self.kv_nodes[0].kv_get_trasanction_result(self.next_tx_seq)
             == "Commit",
-            timeout=120,
+            timeout=180,
         )
         second_version = self.next_tx_seq
         self.next_tx_seq += 1

--- a/tests/kv_put_get_test.py
+++ b/tests/kv_put_get_test.py
@@ -6,7 +6,7 @@ from os import access
 import random
 from test_framework.test_framework import TestFramework
 from utility.kv import (MAX_U64, op_with_address, op_with_key, STREAM_DOMAIN, with_prefix, is_write_permission_denied,
-                        MAX_STREAM_ID, pad, to_key, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
+                        MAX_STREAM_ID, pad, to_key_with_size, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
 from utility.submission import submit_data
 from utility.submission import create_submission
 from utility.utils import (

--- a/tests/kv_recovery_test.py
+++ b/tests/kv_recovery_test.py
@@ -6,7 +6,7 @@ from os import access
 import random
 from test_framework.test_framework import TestFramework
 from utility.kv import (MAX_U64, op_with_address, op_with_key, STREAM_DOMAIN, with_prefix, is_write_permission_denied,
-                        MAX_STREAM_ID, pad, to_key, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
+                        MAX_STREAM_ID, pad, to_key_with_size, to_stream_id, create_kv_data, AccessControlOps, rand_key, rand_write)
 from utility.submission import submit_data
 from utility.submission import create_submission
 from utility.utils import (

--- a/tests/test_framework/kv_node.py
+++ b/tests/test_framework/kv_node.py
@@ -84,7 +84,7 @@ class KVNode(TestNode):
                 ), value[i:])
             i += bytes_per_query
 
-    def hex_to_segment(x):
+    def hex_to_segment(self, x):
         return base64.b64encode(bytes.fromhex(x)).decode("utf-8")
 
     # rpc

--- a/tests/test_framework/kv_node.py
+++ b/tests/test_framework/kv_node.py
@@ -84,9 +84,12 @@ class KVNode(TestNode):
                 ), value[i:])
             i += bytes_per_query
 
+    def hex_to_segment(x):
+        return base64.b64encode(bytes.fromhex(x)).decode("utf-8")
+
     # rpc
     def kv_get_value(self, stream_id, key, start_index, size, version=None):
-        return self.rpc.kv_getValue([stream_id, key, start_index, size, version])
+        return self.rpc.kv_getValue([stream_id, self.hex_to_segment(key), start_index, size, version])
 
     def kv_get_trasanction_result(self, tx_seq):
         return self.rpc.kv_getTransactionResult([tx_seq])
@@ -95,16 +98,16 @@ class KVNode(TestNode):
         return self.rpc.kv_getHoldingStreamIds()
 
     def kv_has_write_permission(self, account, stream_id, key, version=None):
-        return self.rpc.kv_hasWritePermission([account, stream_id, key, version])
+        return self.rpc.kv_hasWritePermission([account, stream_id, self.hex_to_segment(key), version])
 
     def kv_is_admin(self, account, stream_id, version=None):
         return self.rpc.kv_isAdmin([account, stream_id, version])
 
     def kv_is_special_key(self, stream_id, key, version=None):
-        return self.rpc.kv_isSpecialKey([stream_id, key, version])
+        return self.rpc.kv_isSpecialKey([stream_id, self.hex_to_segment(key), version])
 
     def kv_is_writer_of_key(self, account, stream_id, key, version=None):
-        return self.rpc.kv_isWriterOfKey([account, stream_id, key, version])
+        return self.rpc.kv_isWriterOfKey([account, stream_id, self.hex_to_segment(key), version])
 
     def kv_is_writer_of_stream(self, account, stream_id, version=None):
         return self.rpc.kv_isWriterOfStream([account, stream_id, version])

--- a/tests/utility/kv.py
+++ b/tests/utility/kv.py
@@ -101,12 +101,13 @@ def to_stream_id(x):
     return pad(x, 64)
 
 
-def to_key(x):
-    return pad(x, 64)
+def to_key_with_size(x):
+    size = pad(len(x), 6)
+    return size + x
 
 
 def rand_key():
-    return to_key(random.randrange(0, MAX_U64))
+    return hex(random.randrange(0, MAX_U64))[2:]
 
 
 def rand_write(stream_id=None, key=None):
@@ -138,13 +139,13 @@ def create_kv_data(version, reads, writes, access_controls):
     data += bytes.fromhex(pad(len(reads), 8))
     for read in reads:
         data += bytes.fromhex(read[0])
-        data += bytes.fromhex(read[1])
+        data += bytes.fromhex(to_key_with_size(read[1]))
     # write set
     data += bytes.fromhex(pad(len(writes), 8))
     # write set meta
     for write in writes:
         data += bytes.fromhex(write[0])
-        data += bytes.fromhex(write[1])
+        data += bytes.fromhex(to_key_with_size(write[1]))
         data += bytes.fromhex(pad(write[2], 16))
         tags.append(write[0])
         if len(write) == 3:
@@ -166,7 +167,7 @@ def create_kv_data(version, reads, writes, access_controls):
         k += 1
         # key
         if ac[0] in op_with_key:
-            data += bytes.fromhex(ac[k])
+            data += bytes.fromhex(to_key_with_size(ac[k]))
             k += 1
         # address
         if ac[0] in op_with_address:

--- a/tests/utility/kv.py
+++ b/tests/utility/kv.py
@@ -74,6 +74,7 @@ MAX_STREAM_ID = 100
 MAX_DATA_LENGTH = 256 * 1024 * 4
 MIN_DATA_LENGTH = 10
 MAX_U64 = (1 << 64) - 1
+MAX_KEY_LEN = 2000
 
 STREAM_DOMAIN = bytes.fromhex(
     "df2ff3bb0af36c6384e6206552a4ed807f6f6a26e7d0aa6bff772ddc9d4307aa")
@@ -107,7 +108,10 @@ def to_key_with_size(x):
 
 
 def rand_key():
-    return hex(random.randrange(0, MAX_U64))[2:]
+    len = random.randrange(1, MAX_KEY_LEN)
+    if len % 2 == 1:
+        len += 1
+    return ''.join([hex(random.randrange(16))[2:] for i in range(len)])
 
 
 def rand_write(stream_id=None, key=None):

--- a/tests/utility/kv.py
+++ b/tests/utility/kv.py
@@ -103,7 +103,7 @@ def to_stream_id(x):
 
 
 def to_key_with_size(x):
-    size = pad(len(x), 6)
+    size = pad(len(x) // 2, 6)
     return size + x
 
 


### PR DESCRIPTION
Change key size in kv data file from fixed 32 bytes to dynamic size. Now for each key, there is a key size prefix(3B) in file to figure out its size.